### PR TITLE
Some more columns can be null.

### DIFF
--- a/main.go
+++ b/main.go
@@ -370,20 +370,20 @@ ON CONFLICT (name) DO UPDATE SET val=:val, intval=:intval, blobval=:blobval
 	}
 
 	if err := copyRows(pgx, "invoices", struct {
-		Id               int64         `db:"id"`
-		State            int64         `db:"state"`
-		Msatoshi         sql.NullInt64 `db:"msatoshi"`
-		PaymentHash      sqlblob       `db:"payment_hash"`
-		PaymentKey       sqlblob       `db:"payment_key"`
-		Label            string        `db:"label"`
-		ExpiryTime       int64         `db:"expiry_time"`
-		PayIndex         sql.NullInt64 `db:"pay_index"`
-		MsatoshiReceived sql.NullInt64 `db:"msatoshi_received"`
-		PaidTimestamp    sql.NullInt64 `db:"paid_timestamp"`
-		Bolt11           string        `db:"bolt11"`
-		Description      string        `db:"description"`
-		Features         sqlblob       `db:"features"`
-		LocalOfferId     sqlblob       `db:"local_offer_id"`
+		Id               int64          `db:"id"`
+		State            int64          `db:"state"`
+		Msatoshi         sql.NullInt64  `db:"msatoshi"`
+		PaymentHash      sqlblob        `db:"payment_hash"`
+		PaymentKey       sqlblob        `db:"payment_key"`
+		Label            string         `db:"label"`
+		ExpiryTime       int64          `db:"expiry_time"`
+		PayIndex         sql.NullInt64  `db:"pay_index"`
+		MsatoshiReceived sql.NullInt64  `db:"msatoshi_received"`
+		PaidTimestamp    sql.NullInt64  `db:"paid_timestamp"`
+		Bolt11           string         `db:"bolt11"`
+		Description      sql.NullString `db:"description"`
+		Features         sqlblob        `db:"features"`
+		LocalOfferId     sqlblob        `db:"local_offer_id"`
 	}{}, "id"); err != nil {
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -330,7 +330,7 @@ ON CONFLICT (name) DO UPDATE SET val=:val, intval=:intval, blobval=:blobval
 		ChannelId           sql.NullInt64 `db:"channel_id"`
 		PeerId              sqlblob       `db:"peer_id"`
 		CommitmentPoint     sqlblob       `db:"commitment_point"`
-		ConfirmationHeight  int64         `db:"confirmation_height"`
+		ConfirmationHeight  sql.NullInt64 `db:"confirmation_height"`
 		SpendHeight         sql.NullInt64 `db:"spend_height"`
 		ScriptPubKey        sqlblob       `db:"scriptpubkey"`
 		ReservedTil         sql.NullInt64 `db:"reserved_til"`


### PR DESCRIPTION
Couple other bugs I ran into and fixed myself.

`confirmation_height` in the `outputs` table can be null, and gets explicitly set sometimes in wallet/db.c
```
{SQL("ALTER TABLE outputs ADD COLUMN confirmation_height INTEGER "
	"REFERENCES blocks(height) ON DELETE SET NULL;"),
```


`description` in the `invoices` table can also be null in really old databases, since the column wasn't added until later.
```
{SQL("ALTER TABLE invoices ADD description TEXT;"), NULL},
```